### PR TITLE
ci(release): add goreleaser and container image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,44 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+  publish-release:
+    needs: [release-please, lint, tidy, test]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker images
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./Dockerfile.release
+          platforms: linux/386,linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ needs.release-please.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Release binaries
+dist/
+
 # Go workspace file
 go.work
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,64 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}"
+    goos:
+      - "linux"
+      - "darwin"
+      - "freebsd"
+      - "openbsd"
+      - "netbsd"
+      - "windows"
+    goarch:
+      - "386"
+      - "amd64"
+      - "arm"
+      - "arm64"
+    goamd64:
+      - "v1"
+    goarm64:
+      - "v8.0"
+    goarm:
+      - "6"
+      - "7"
+    ignore:
+      # Windows doesn't support 32-bit ARM
+      - goos: windows
+        goarch: arm
+      # Darwin (macOS) doesn't support 32-bit architectures anymore
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  disable: true
+
+archives:
+  - id: bin
+    format: binary
+  - id: tar
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: |-
+      {{ .ProjectName }}-{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}
+    wrap_in_directory: true
+    files:
+      - README.md
+      - LICENSE

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,39 @@
+FROM alpine:3 AS builder
+
+ARG TARGETPLATFORM
+RUN apk --no-cache add tzdata
+
+# Copy in whole dist directory produced by goreleaser, and move the correct
+# binary for the current target platform into the root of the image.
+COPY dist/ /tmp/
+RUN set -x \
+    && case "$TARGETPLATFORM" in \
+    "linux/amd64") \
+    mv /tmp/go-mcp-time_linux_amd64_v1/go-mcp-time /go-mcp-time \
+    ;; \
+    "linux/arm64") \
+    mv /tmp/go-mcp-time_linux_arm64_v8.0/go-mcp-time /go-mcp-time \
+    ;; \
+    "linux/arm/v6") \
+    mv /tmp/go-mcp-time_linux_arm_6/go-mcp-time /go-mcp-time \
+    ;; \
+    "linux/arm/v7") \
+    mv /tmp/go-mcp-time_linux_arm_7/go-mcp-time /go-mcp-time \
+    ;; \
+    "linux/386") \
+    mv /tmp/go-mcp-time_linux_386/go-mcp-time /go-mcp-time \
+    ;; \
+    *) \
+    echo "Unsupported platform: $TARGETPLATFORM" >&2; \
+    exit 1 \
+    ;; \
+    esac \
+    && chmod +x /go-mcp-time
+
+FROM scratch
+
+# Copy in the zoneinfo directory so the binary can parse IANA timezone names.
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /go-mcp-time /go-mcp-time
+
+ENTRYPOINT ["/go-mcp-time"]

--- a/main.go
+++ b/main.go
@@ -14,18 +14,40 @@ import (
 	"github.com/jimeh/go-mcp-time/server"
 )
 
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
+
 func main() {
 	var localTimezone string
+	var showVersion bool
 	flag.StringVar(&localTimezone, "local-timezone", "",
 		"Override local timezone (IANA timezone name)")
+	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.Parse()
 
+	if showVersion {
+		fmt.Printf("go-mcp-time %s\n", version)
+		fmt.Printf("commit: %s\n", commit)
+		fmt.Printf("built: %s\n", date)
+
+		os.Exit(0)
+	}
+
 	if localTimezone == "" {
-		zone, _ := time.Now().Zone()
-		if zone != "" {
-			localTimezone = zone
+		// Check TZ environment variable first
+		if tz := os.Getenv("TZ"); tz != "" {
+			localTimezone = tz
 		} else {
-			localTimezone = "UTC"
+			// Try to get the system timezone location
+			now := time.Now()
+			if loc := now.Location(); loc != nil && loc.String() != "" {
+				localTimezone = loc.String()
+			} else {
+				localTimezone = "UTC"
+			}
 		}
 	}
 


### PR DESCRIPTION
- Add .goreleaser.yaml with multi-platform binary builds
- Add Dockerfile.release for container image builds
- Add publish-release job to CI workflow
- Support macOS, Linux, FreeBSD, OpenBSD, NetBSD, Windows platforms
- Support linux/386, amd64, arm64, arm/v6, arm/v7 container platforms
- Publish to GitHub releases and GitHub Container Registry

🤖 Generated with Claude Code

Co-Authored-By: Claude noreply@anthropic.com